### PR TITLE
Responsive People tile

### DIFF
--- a/src/common/TileList/TilePeople/index.js
+++ b/src/common/TileList/TilePeople/index.js
@@ -5,15 +5,16 @@ import { PersonImage } from "./Image";
 export const PeopleListTile = ({ name, poster, id, character }) => {
   return (
     <GetDetailsPeopleLink to={`/people/${id}`} key={id}>
-      <Container>
+      
         <Wrapper>
           <PersonImage poster={poster} />
-          <Content>
+          
             <PersonName>{name}</PersonName>
+            
             <CharacterName>{character}</CharacterName>
-          </Content>
+         
         </Wrapper>
-      </Container>
+      
     </GetDetailsPeopleLink>
   );
 };

--- a/src/common/TileList/TilePeople/styled.js
+++ b/src/common/TileList/TilePeople/styled.js
@@ -8,6 +8,7 @@ export const Wrapper = styled.article`
   height: 100%;
   border-radius: 5px;
   box-shadow: 0px 4px 12px 0px rgba(186, 199, 213, 0.5);
+  text-align: center;
 
   @media (max-width: ${({ theme }) => theme.breakpoint.small}) {
     max-height: 290px;


### PR DESCRIPTION
**In this update:**

- Removed `<Container>` and `<Content>` from Tile People. 



